### PR TITLE
fix processor not created error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ scale_1 = {
 # configure the second one for precise style control to each masked input.
 pipe.set_ip_adapter_scale([1.0, scale_1])
 
+processor = IPAdapterMaskProcessor()
 female_mask = Image.open("./assets/female_mask.png")
 male_mask = Image.open("./assets/male_mask.png")
 background_mask = Image.open("./assets/background_mask.png")


### PR DESCRIPTION
Add IPAdapterMaskProcessor initialization in READMD scripts. The script has now been tested in local repo and work as expected.